### PR TITLE
Upgrade vsock-rs and remove dependence on nix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ futures = "0.3.5"
 iovec = "0.1.4"
 libc = "0.2.79"
 mio = "0.6.20"
-nix = "0.19.1"
-vsock = "0.2.2"
+vsock = "0.2.3"
 tokio = { version = "0.2", features = ["io-driver", "stream"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-vsock"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["fsyncd", "rust-vsock"]
 description = "Asynchronous Virtio socket support for Rust"
 repository = "https://github.com/rust-vsock/tokio-vsock"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,4 @@ mod stream;
 
 pub use listener::{Incoming, VsockListener};
 pub use stream::VsockStream;
+pub use vsock::{SockAddr, VsockAddr};

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -46,8 +46,8 @@
 use std::io::{ErrorKind, Result};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
+use crate::SockAddr;
 use futures::ready;
-use nix::sys::socket::SockAddr;
 use std::mem;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -46,7 +46,7 @@
 use std::io::{ErrorKind, Result};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
-use crate::SockAddr;
+use crate::{SockAddr, VsockAddr};
 use futures::ready;
 use std::mem;
 use std::pin::Pin;
@@ -72,6 +72,11 @@ impl VsockListener {
     pub fn bind(addr: &SockAddr) -> Result<Self> {
         let l = super::mio::VsockListener::bind(addr)?;
         Self::new(l)
+    }
+
+    /// Create a new Virtio socket listener with specified cid and port.
+    pub fn bind_with_cid_port(cid: u32, port: u32) -> Result<Self> {
+        Self::bind(&SockAddr::Vsock(VsockAddr::new(cid, port)))
     }
 
     /// Attempt to accept a connection and create a new connected socket if

--- a/src/mio/listener.rs
+++ b/src/mio/listener.rs
@@ -40,9 +40,9 @@
 use std::io::Result;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
+use crate::SockAddr;
 use mio::unix::EventedFd;
 use mio::{Evented, Poll, PollOpt, Ready, Token};
-use nix::sys::socket::SockAddr;
 
 #[derive(Debug)]
 pub struct VsockListener {

--- a/src/mio/stream.rs
+++ b/src/mio/stream.rs
@@ -43,10 +43,10 @@ use std::mem::size_of;
 use std::net::Shutdown;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
+use crate::SockAddr;
 use libc::*;
 use mio::unix::EventedFd;
 use mio::{Evented, Poll, PollOpt, Ready, Token};
-use nix::sys::socket::SockAddr;
 
 use super::iovec::unix as iovec;
 use super::iovec::IoVec;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -47,9 +47,9 @@ use std::io::{ErrorKind, Read, Result, Write};
 use std::net::Shutdown;
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 
+use crate::SockAddr;
 use futures::{future::poll_fn, ready};
 use mio::Ready;
-use nix::sys::socket::SockAddr;
 use std::mem::{self, MaybeUninit};
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -47,7 +47,7 @@ use std::io::{ErrorKind, Read, Result, Write};
 use std::net::Shutdown;
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 
-use crate::SockAddr;
+use crate::{SockAddr, VsockAddr};
 use futures::{future::poll_fn, ready};
 use mio::Ready;
 use std::mem::{self, MaybeUninit};
@@ -68,12 +68,18 @@ impl VsockStream {
         Ok(Self { io })
     }
 
+    /// Open a connection to a remote host.
     pub async fn connect(addr: &SockAddr) -> Result<Self> {
         let stream = super::mio::VsockStream::connect(addr)?;
         let stream = Self::new(stream)?;
 
         poll_fn(|cx| stream.io.poll_write_ready(cx)).await?;
         Ok(stream)
+    }
+
+    /// Open a connection to a remote host with specified cid and port.
+    pub async fn connect_with_cid_port(cid: u32, port: u32) -> Result<Self> {
+        Self::connect(&SockAddr::Vsock(VsockAddr::new(cid, port))).await
     }
 
     /// Create a new socket from an existing blocking socket.

--- a/test_server/Cargo.lock
+++ b/test_server/Cargo.lock
@@ -415,7 +415,6 @@ dependencies = [
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-vsock 0.2.2",
 ]
@@ -462,9 +461,8 @@ dependencies = [
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "vsock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vsock 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -484,7 +482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vsock"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.85 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -587,7 +585,7 @@ dependencies = [
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-"checksum vsock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "07a39f9e24a5782c392413c51eb05f22d5f0db486f95f0ce72db5ab46a45904c"
+"checksum vsock 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "50e2ef09834e1d203d24556512c0e58e66de203440bd9d74c30a33f7240091c6"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/test_server/Cargo.toml
+++ b/test_server/Cargo.toml
@@ -10,6 +10,5 @@ edition = "2018"
 clap = "2.33.0"
 futures = "0.3.5"
 libc = "0.2.79"
-nix = "0.19.1"
 tokio = { version = "0.2", features = ["macros", "io-driver", "stream", "rt-threaded", "rt-core", "io-util",] }
 tokio-vsock = { path = "../" }

--- a/test_server/src/main.rs
+++ b/test_server/src/main.rs
@@ -16,9 +16,8 @@
 
 use clap::{crate_authors, crate_version, App, Arg};
 use futures::StreamExt as _;
-use nix::sys::socket::{SockAddr, VsockAddr};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio_vsock::VsockListener;
+use tokio_vsock::{SockAddr, VsockAddr, VsockListener};
 
 /// A simple Virtio socket server that uses Hyper to response to requests.
 #[tokio::main]

--- a/tests/vsock.rs
+++ b/tests/vsock.rs
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-use nix::sys::socket::{SockAddr, VsockAddr};
 use rand::RngCore;
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio_vsock::VsockStream;
+use tokio_vsock::{SockAddr, VsockAddr, VsockStream};
 
 const TEST_BLOB_SIZE: usize = 100_000;
 const TEST_BLOCK_SIZE: usize = 5_000;


### PR DESCRIPTION
- Bump `vsock-rs` from 0.2.2 to 0.2.3
- Remove dependence on nix and re-export SockAddr, VsockAddr
- Add methods connect_with_cid_port and bind_with_cid_port
- Bump version to 0.2.3