### PR TITLE
Update vsock dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["test_fixture"]
 bytes = "0.4.12"
 futures = "0.3"
 libc = "0.2.79"
-vsock = "0.2.4"
+vsock = "0.2.5"
 tokio = { version = "1", features = ["net"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Bump vsock dependency to 0.2.5

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>