### PR TITLE
Handle interrupts

### DIFF
--- a/src/listener.rs
+++ b/src/listener.rs
@@ -100,6 +100,8 @@ impl VsockListener {
 
             match guard.try_io(|inner| inner.get_ref().accept()) {
                 Ok(Ok((inner, addr))) => return Ok((inner, addr)).into(),
+                // continue on interrupt...
+                Ok(Err(ref e)) if e.kind() == std::io::ErrorKind::Interrupted => continue,
                 Ok(Err(e)) => return Err(e).into(),
                 Err(_would_block) => continue,
             }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -137,6 +137,7 @@ impl VsockStream {
 
             match guard.try_io(|inner| inner.get_ref().write(buf)) {
                 Ok(Ok(n)) => return Ok(n).into(),
+                Ok(Err(ref e)) if e.kind() == std::io::ErrorKind::Interrupted => continue,
                 Ok(Err(e)) => return Err(e).into(),
                 Err(_would_block) => continue,
             }
@@ -164,6 +165,7 @@ impl VsockStream {
                     buf.advance(n);
                     return Ok(()).into();
                 }
+                Ok(Err(ref e)) if e.kind() == std::io::ErrorKind::Interrupted => continue,
                 Ok(Err(e)) => return Err(e).into(),
                 Err(_would_block) => {
                     continue;


### PR DESCRIPTION
This is a second attempt at handling interrupts in tokio-vsock. (First attempt: #8)

Now, after some spelunking, it appears the cause of interrupts is `firecracker` itself.

I've been seeing [`raising IRQ`](https://github.com/firecracker-microvm/firecracker/blob/9720e6f917474bd97973bc4e33bf5d83fe8d59a1/src/devices/src/virtio/vsock/device.rs#L123) logs from firecracker concerning the guest vsock.

I don't exactly know what purpose this serves, but the end result is that we need to handle interrupts in a graceful manner.

Therefore I'm hoping this simple PR can get approved and merge or else we're forced to keep using my fork. This is also fine, but given then rising popularity of Firecracker, I expect more people will stumble on this issue.