### PR TITLE
gitignore: ignore .vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 .idea/
 *.iml
 Cargo.lock
+.vscode


### PR DESCRIPTION
.vscode directory stores the workspace settings of the "Visual Studio Code" editor.

We should ignore it for everybody has her/his own editor settings.
