### PR TITLE
 Implement Connected trait from tonic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ futures = "0.3"
 libc = "0.2.79"
 vsock = "0.2.4"
 tokio = { version = "1", features = ["net"] }
+tonic = "0.8.0"
 
 [dev-dependencies]
 sha2 = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 exclude = ["test_fixture"]
 
 [features]
-tonic-conn = ["dep:tonic"]
+tonic-conn = ["tonic"]
 
 [dependencies]
 bytes = "0.4.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,16 @@ license = "Apache-2.0"
 edition = "2018"
 exclude = ["test_fixture"]
 
+[features]
+tonic-conn = ["dep:tonic"]
+
 [dependencies]
 bytes = "0.4.12"
 futures = "0.3"
 libc = "0.2.79"
 vsock = "0.2.4"
 tokio = { version = "1", features = ["net"] }
-tonic = "0.6.2"
+tonic = { version = "0.6.2", optional = true }
 
 [dev-dependencies]
 sha2 = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3"
 libc = "0.2.79"
 vsock = "0.2.4"
 tokio = { version = "1", features = ["net"] }
-tonic = "0.8.0"
+tonic = "0.6.2"
 
 [dev-dependencies]
 sha2 = "0.9.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,5 +18,7 @@ mod listener;
 mod stream;
 
 pub use listener::{Incoming, VsockListener};
-pub use stream::{VsockConnectInfo, VsockStream};
+#[cfg(feature = "tonic-conn")]
+pub use stream::VsockConnectInfo;
+pub use stream::VsockStream;
 pub use vsock::{SockAddr, VsockAddr};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-pub mod listener;
-pub mod stream;
+mod listener;
+mod stream;
 
 pub use listener::{Incoming, VsockListener};
 pub use stream::{VsockConnectInfo, VsockStream};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-mod listener;
-mod stream;
+pub mod listener;
+pub mod stream;
 
 pub use listener::{Incoming, VsockListener};
 pub use stream::{VsockConnectInfo, VsockStream};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,5 +18,5 @@ mod listener;
 mod stream;
 
 pub use listener::{Incoming, VsockListener};
-pub use stream::VsockStream;
+pub use stream::{VsockConnectInfo, VsockStream};
 pub use vsock::{SockAddr, VsockAddr};

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -55,6 +55,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+#[cfg(feature = "tonic-conn")]
 use tonic::transport::server::Connected;
 
 /// An I/O object representing a Virtio socket connected to a remote endpoint.
@@ -180,11 +181,13 @@ impl VsockStream {
 ///
 /// See [`Connected`] for more details.
 ///
+#[cfg(feature = "tonic-conn")]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct VsockConnectInfo {
     peer_addr: Option<SockAddr>,
 }
 
+#[cfg(feature = "tonic-conn")]
 impl VsockConnectInfo {
     /// Return the remote address the IO resource is connected too.
     pub fn peer_addr(&self) -> Option<SockAddr> {
@@ -192,6 +195,9 @@ impl VsockConnectInfo {
     }
 }
 
+/// Allow consumers of VsockStream to check that it is connected and valid before use.
+///
+#[cfg(feature = "tonic-conn")]
 impl Connected for VsockStream {
     type ConnectInfo = VsockConnectInfo;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -55,6 +55,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tonic::transport::server::Connected;
 
 /// An I/O object representing a Virtio socket connected to a remote endpoint.
 #[derive(Debug)]
@@ -171,6 +172,32 @@ impl VsockStream {
                     continue;
                 }
             }
+        }
+    }
+}
+
+/// Connection info for a Vsock Stream.
+///
+/// See [`Connected`] for more details.
+///
+#[derive(Debug, Clone)]
+pub struct VsockConnectInfo {
+    peer_addr: Option<SockAddr>,
+}
+
+impl VsockConnectInfo {
+    /// Return the remote address the IO resource is connected too.
+    pub fn peer_addr(&self) -> Option<SockAddr> {
+        self.peer_addr
+    }
+}
+
+impl Connected for VsockStream {
+    type ConnectInfo = VsockConnectInfo;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        VsockConnectInfo {
+            peer_addr: self.peer_addr().ok(),
         }
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -180,7 +180,7 @@ impl VsockStream {
 ///
 /// See [`Connected`] for more details.
 ///
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct VsockConnectInfo {
     peer_addr: Option<SockAddr>,
 }


### PR DESCRIPTION
Implement the `tonic::transport::server::Connected` trait onto
`VsockStream` such that it may be used to build a tonic server.