### PR TITLE
Bump dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,16 @@ exclude = ["test_fixture"]
 tonic-conn = ["tonic"]
 
 [dependencies]
-bytes = "0.4.12"
+bytes = "1.3.0"
 futures = "0.3"
-libc = "0.2.79"
-vsock = "0.2.4"
+libc = "0.2.138"
+vsock = "0.3.0"
 tokio = { version = "1", features = ["net"] }
-tonic = { version = "0.6.2", optional = true }
+tonic = { version = "0.8.3", optional = true }
 
 [dev-dependencies]
-sha2 = "0.9.0"
-rand = "0.8.3"
+sha2 = "0.10.6"
+rand = "0.8.5"
 tokio = { version = "1", features = ["macros", "rt", "io-util"] }
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,4 @@ pub use stream::VsockStream;
 #[cfg(feature = "tonic-conn")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tonic-conn")))]
 pub use tonic_support::VsockConnectInfo;
-pub use vsock::{SockAddr, VsockAddr};
+pub use vsock::VsockAddr;

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -53,7 +53,7 @@ use std::task::{Context, Poll};
 use tokio::io::unix::AsyncFd;
 
 use crate::stream::VsockStream;
-use crate::SockAddr;
+use crate::VsockAddr;
 
 /// An I/O object representing a Virtio socket listening for incoming connections.
 #[derive(Debug)]
@@ -76,13 +76,13 @@ impl VsockListener {
     }
 
     /// Accepts a new incoming connection to this listener.
-    pub async fn accept(&mut self) -> Result<(VsockStream, SockAddr)> {
+    pub async fn accept(&mut self) -> Result<(VsockStream, VsockAddr)> {
         poll_fn(|cx| self.poll_accept(cx)).await
     }
 
     /// Attempt to accept a connection and create a new connected socket if
     /// successful.
-    pub fn poll_accept(&mut self, cx: &mut Context<'_>) -> Poll<Result<(VsockStream, SockAddr)>> {
+    pub fn poll_accept(&mut self, cx: &mut Context<'_>) -> Poll<Result<(VsockStream, VsockAddr)>> {
         let (inner, addr) = ready!(self.poll_accept_std(cx))?;
         let inner = VsockStream::new(inner)?;
 
@@ -94,7 +94,7 @@ impl VsockListener {
     pub fn poll_accept_std(
         &mut self,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(vsock::VsockStream, SockAddr)>> {
+    ) -> Poll<Result<(vsock::VsockStream, VsockAddr)>> {
         loop {
             let mut guard = ready!(self.inner.poll_read_ready(cx))?;
 
@@ -109,7 +109,7 @@ impl VsockListener {
     }
 
     /// The local address that this listener is bound to.
-    pub fn local_addr(&self) -> Result<SockAddr> {
+    pub fn local_addr(&self) -> Result<VsockAddr> {
         self.inner.get_ref().local_addr()
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -48,7 +48,7 @@ use std::net::Shutdown;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
 use crate::split::{split as new_split, ReadHalf, WriteHalf};
-use crate::{SockAddr, VsockAddr};
+use crate::VsockAddr;
 use futures::ready;
 use libc::*;
 use std::mem::{self, size_of};
@@ -142,12 +142,12 @@ impl VsockStream {
     }
 
     /// The local address that this socket is bound to.
-    pub fn local_addr(&self) -> Result<SockAddr> {
+    pub fn local_addr(&self) -> Result<VsockAddr> {
         self.inner.get_ref().local_addr()
     }
 
     /// The remote address that this socket is connected to.
-    pub fn peer_addr(&self) -> Result<SockAddr> {
+    pub fn peer_addr(&self) -> Result<VsockAddr> {
         self.inner.get_ref().peer_addr()
     }
 

--- a/src/tonic_support.rs
+++ b/src/tonic_support.rs
@@ -1,6 +1,6 @@
 use tonic::transport::server::Connected;
 
-use crate::{SockAddr, VsockStream};
+use crate::{VsockAddr, VsockStream};
 
 /// Connection info for a Vsock Stream.
 ///
@@ -9,13 +9,13 @@ use crate::{SockAddr, VsockStream};
 #[cfg_attr(docsrs, doc(cfg(feature = "tonic-conn")))]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct VsockConnectInfo {
-    peer_addr: Option<SockAddr>,
+    peer_addr: Option<VsockAddr>,
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "tonic-conn")))]
 impl VsockConnectInfo {
     /// Return the remote address the IO resource is connected too.
-    pub fn peer_addr(&self) -> Option<SockAddr> {
+    pub fn peer_addr(&self) -> Option<VsockAddr> {
         self.peer_addr
     }
 }


### PR DESCRIPTION
Update vsock from 0.2.4 to 0.3.0. Changes are made according to https://github.com/rust-vsock/vsock-rs/commit/db589aa30ce36826198aa63df8e81d7a175f5266.

