### PR TITLE
release: v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-vsock"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["fsyncd", "rust-vsock"]
 description = "Asynchronous Virtio socket support for Rust"
 repository = "https://github.com/rust-vsock/tokio-vsock"


### PR DESCRIPTION
Bump the major version for API has changed in #25.