### PR TITLE
Cast size_of::<sockaddr_vm>() to socklen_t

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -89,7 +89,7 @@ impl VsockStream {
             connect(
                 socket,
                 &vsock_addr as *const _ as *const sockaddr,
-                size_of::<sockaddr_vm>() as u32,
+                size_of::<sockaddr_vm>() as socklen_t,
             )
         } < 0
         {


### PR DESCRIPTION
 The len argument of connect isn't guaranteed to always be u32
 (for example, some android platforms use i32).

 Fixes rust-vsock/tokio-vsock#28