### PR TITLE
feat!: Mirror tokio Stream Api with split and into_split

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ mod stream;
 mod tonic_support;
 
 pub use listener::{Incoming, VsockListener};
-pub use split::{ReadHalf, WriteHalf};
+pub use split::{OwnedReadHalf, OwnedWriteHalf, ReadHalf, WriteHalf};
 pub use stream::VsockStream;
 #[cfg(feature = "tonic-conn")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tonic-conn")))]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -47,7 +47,7 @@ use std::io::{Error, Read, Result, Write};
 use std::net::Shutdown;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
-use crate::split::{split as new_split, ReadHalf, WriteHalf};
+use crate::split::{split_owned, OwnedReadHalf, OwnedWriteHalf, ReadHalf, WriteHalf};
 use crate::VsockAddr;
 use futures::ready;
 use libc::*;
@@ -158,11 +158,17 @@ impl VsockStream {
 
     /// Splits a single value implementing `AsyncRead + AsyncWrite` into separate
     /// `AsyncRead` and `AsyncWrite` handles.
+    pub fn split(&mut self) -> (ReadHalf<'_>, WriteHalf<'_>) {
+        crate::split::split(self)
+    }
+
+    /// Splits a single value implementing `AsyncRead + AsyncWrite` into separate
+    /// `AsyncRead` and `AsyncWrite` handles.
     ///
-    /// To restore this read/write object from its `ReadHalf` and
-    /// `WriteHalf` use [`unsplit`](ReadHalf::unsplit()).
-    pub fn split(self) -> (ReadHalf, WriteHalf) {
-        new_split(self)
+    /// To restore this read/write object from its `OwnedReadHalf` and
+    /// `OwnedWriteHalf` use [`unsplit`](OwnedReadHalf::unsplit()).
+    pub fn into_split(self) -> (OwnedReadHalf, OwnedWriteHalf) {
+        split_owned(self)
     }
 
     pub(crate) fn poll_write_priv(&self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {


### PR DESCRIPTION
VsockStream has been reworked to have a Owned (the previous API) and a Borrowed (the new API) variant. This comes with the following **Breaking Changes**:
- `VsockStream::split(self)` has been renamed `VsockStream::into_split`
- `VsockStream::split(&mut self)` has been added
- `split::{ReadHalf, WriteHalf}` have been renamed to `split::{OwnedReadHalf, OwnedWriteHalf}`
- New structs have been added:
  - `split::ReadHalf<'a>` a borrowed ReadHalf of a VsockStream
  - `split::WriteHalf<'a>` a borrowed WriteHalf of a VsockStream

The borrowed variants have the benefit of beeing chaper to construct/use as they rely on the fact that a `&mut` must be unique, thus when they are dropped the VsockStream ca be safely used again.

It also helps making it consistant with the tokio sockets and introduces no extra unsafe impls.