### PR TITLE
feat: Expose vsock::VM_ADDR_* constants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,6 @@ pub use stream::VsockStream;
 #[cfg(feature = "tonic-conn")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tonic-conn")))]
 pub use tonic_support::VsockConnectInfo;
-pub use vsock::VsockAddr;
+pub use vsock::{
+    VsockAddr, VMADDR_CID_ANY, VMADDR_CID_HOST, VMADDR_CID_HYPERVISOR, VMADDR_CID_LOCAL,
+};


### PR DESCRIPTION
These constants are useful when constructing new `VsockAddr`s and are currently not reexported thus making the consuming library/application require to either write the values themselves (very brittle), or add an unnecessary dependency on either nix or vsock.

tokio-vsock already depends on vsock-rs, thus we can just reexport these values.