### PR TITLE
feat(split): Rely on tokio's sync primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bytes = "1.3.0"
 futures = "0.3"
 libc = "0.2.138"
 vsock = "0.3.0"
-tokio = { version = "1", features = ["net"] }
+tokio = { version = "1", features = ["net", "sync"] }
 tonic = { version = "0.8.3", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This removes Atomics in favor of tokio's Mutex. It should be a safer alternative (and less likely to cause UB).