### PR TITLE
fix: Use VsockAddr instead of cid and port where appropiate

### DIFF
--- a/src/listener.rs
+++ b/src/listener.rs
@@ -70,8 +70,8 @@ impl VsockListener {
     }
 
     /// Create a new Virtio socket listener associated with this event loop.
-    pub fn bind(cid: u32, port: u32) -> Result<Self> {
-        let l = vsock::VsockListener::bind_with_cid_port(cid, port)?;
+    pub fn bind(addr: VsockAddr) -> Result<Self> {
+        let l = vsock::VsockListener::bind_with_cid_port(addr.cid(), addr.port())?;
         Self::new(l)
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -72,9 +72,7 @@ impl VsockStream {
     }
 
     /// Open a connection to a remote host.
-    pub async fn connect(cid: u32, port: u32) -> Result<Self> {
-        let vsock_addr = VsockAddr::new(cid, port);
-
+    pub async fn connect(addr: VsockAddr) -> Result<Self> {
         let socket = unsafe { socket(AF_VSOCK, SOCK_STREAM | SOCK_CLOEXEC, 0) };
         if socket < 0 {
             return Err(Error::last_os_error());
@@ -88,7 +86,7 @@ impl VsockStream {
         if unsafe {
             connect(
                 socket,
-                &vsock_addr as *const _ as *const sockaddr,
+                &addr as *const _ as *const sockaddr,
                 size_of::<sockaddr_vm>() as socklen_t,
             )
         } < 0

--- a/test_server/src/main.rs
+++ b/test_server/src/main.rs
@@ -17,7 +17,7 @@
 use clap::{crate_authors, crate_version, App, Arg};
 use futures::StreamExt as _;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio_vsock::VsockListener;
+use tokio_vsock::{VsockListener, VsockAddr};
 
 /// A simple Virtio socket server that uses Hyper to response to requests.
 #[tokio::main]
@@ -42,8 +42,8 @@ async fn main() -> Result<(), ()> {
         .parse::<u32>()
         .expect("port must be a valid integer");
 
-    let listener = VsockListener::bind(libc::VMADDR_CID_ANY, listen_port)
-        .expect("unable to bind virtio listener");
+    let addr = VsockAddr::new(libc::VMADDR_CID_ANY, listen_port);
+    let listener = VsockListener::bind(addr).expect("unable to bind virtio listener");
 
     println!("Listening for connections on port: {}", listen_port);
 


### PR DESCRIPTION
This follows the API of tokio where `bind` and `connect` take an `addr` argument instead of a separate IP/hostname and port.

Tokio actually takes a `addr: impl ToSockAddrs` because of DNS resolution (ie. `localhost` can be both `127.0.0.1` and `::1` or any number of IPs for that matter). Vsocks do not do this so it makes sense to keep the argument the same (although we could take `addr: impl Into<Vsock>` instead in case we add some interesting `From` and `TryFrom` methods).