### PR TITLE
docs: definitely no longer alpha quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 Asynchronous Virtio socket support for Rust. The implementation is 
 based off of Tokio and Mio's `TCPListener` and `TCPStream` interfaces.
 
-tokio-vsock is for the most part **pre-alpha** quality, so there are probably 
-**sharp edges**. Please test it thoroughly before using in production. Happy to receive
-pull requests and issue reports.
-
 ## Use Cases
 
 The most common use case for tokio-vsock would be writing agents for microvm
@@ -30,7 +26,7 @@ Setup the required Virtio kernel modules:
 make kmod
 ```
 
-Start the test vm, you can shutdown the vm with the keyboard shortcut ```Ctrl+A``` and then ```x```:
+Start the test vm, you can shutdown the vm with the keyboard shortcut `Ctrl+A` and then `x`:
 
 ```
 make vm


### PR DESCRIPTION
Given `tokio-vsock` has been used in production for a number of years now, it's definitely no longer alpha quality (which was a comment I added to the README, when I initially released the project as a PoC).

Addresses: #44 