### PR TITLE
build: Add support for macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ tonic-conn = ["tonic"]
 bytes = "1.3.0"
 futures = "0.3"
 libc = "0.2.138"
-vsock = "0.5.0"
+vsock = "0.5.1"
 tokio = { version = "1", features = ["net", "sync"] }
 tonic = { version = "0.12.0", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,6 @@ pub use stream::VsockStream;
 #[cfg(feature = "tonic-conn")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tonic-conn")))]
 pub use tonic_support::VsockConnectInfo;
-pub use vsock::{
-    VsockAddr, VMADDR_CID_ANY, VMADDR_CID_HOST, VMADDR_CID_HYPERVISOR, VMADDR_CID_LOCAL,
-};
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub use vsock::VMADDR_CID_LOCAL;
+pub use vsock::{VsockAddr, VMADDR_CID_ANY, VMADDR_CID_HOST, VMADDR_CID_HYPERVISOR};

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -74,12 +74,12 @@ impl VsockStream {
 
     /// Open a connection to a remote host.
     pub async fn connect(addr: VsockAddr) -> Result<Self> {
-        let socket = unsafe { socket(AF_VSOCK, SOCK_STREAM | SOCK_CLOEXEC, 0) };
+        let socket = unsafe { socket(AF_VSOCK, SOCK_STREAM, 0) };
         if socket < 0 {
             return Err(Error::last_os_error());
         }
 
-        if unsafe { fcntl(socket, F_SETFL, O_NONBLOCK) } < 0 {
+        if unsafe { fcntl(socket, F_SETFL, O_NONBLOCK | O_CLOEXEC) } < 0 {
             let _ = unsafe { close(socket) };
             return Err(Error::last_os_error());
         }

--- a/tests/vsock.rs
+++ b/tests/vsock.rs
@@ -17,7 +17,9 @@
 use rand::RngCore;
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio_vsock::{VsockAddr, VsockListener, VsockStream};
+#[cfg(target_os = "linux")]
+use tokio_vsock::VsockListener;
+use tokio_vsock::{VsockAddr, VsockStream};
 
 const TEST_BLOB_SIZE: usize = 100_000;
 const TEST_BLOCK_SIZE: usize = 5_000;
@@ -90,6 +92,7 @@ async fn test_vsock_conn_error() {
 ///
 /// source: https://github.com/tokio-rs/tokio/blob/fc9518b62714daac9a38b46c698b94ac5d5b1ca2/tokio/tests/tcp_split.rs
 #[tokio::test]
+#[cfg(target_os = "linux")]
 async fn split_vsock() {
     const MSG: &[u8] = b"split";
     const PORT: u32 = 8002;
@@ -139,6 +142,7 @@ async fn split_vsock() {
 ///
 /// source: https://github.com/tokio-rs/tokio/blob/fc9518b62714daac9a38b46c698b94ac5d5b1ca2/tokio/tests/tcp_split.rs
 #[tokio::test]
+#[cfg(target_os = "linux")]
 async fn into_split_vsock() {
     const MSG: &[u8] = b"split";
     const PORT: u32 = 8001;


### PR DESCRIPTION
I added macOS support for vsock-rs by PR https://github.com/rust-vsock/vsock-rs/pull/44. This PR adds macOS support for tokio-vsock.
This change is needed to use this crate in the macOS guest of Virtualization.framework.

One issue of this change is that it needs the latest vsock-rs. It can be resolved by releasing a new version of vsock-rs.