### PR TITLE
Prepare for 0.6.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-vsock"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["fsyncd", "rust-vsock"]
 description = "Asynchronous Virtio socket support for Rust"
 repository = "https://github.com/rust-vsock/tokio-vsock"


### PR DESCRIPTION
Bump the major version for API changes in #47.

As requested in #51.