### PR TITLE
Use `&self` instead of `&mut self` for poll_accept

### DIFF
--- a/src/listener.rs
+++ b/src/listener.rs
@@ -77,13 +77,13 @@ impl VsockListener {
     }
 
     /// Accepts a new incoming connection to this listener.
-    pub async fn accept(&mut self) -> Result<(VsockStream, VsockAddr)> {
+    pub async fn accept(&self) -> Result<(VsockStream, VsockAddr)> {
         poll_fn(|cx| self.poll_accept(cx)).await
     }
 
     /// Attempt to accept a connection and create a new connected socket if
     /// successful.
-    pub fn poll_accept(&mut self, cx: &mut Context<'_>) -> Poll<Result<(VsockStream, VsockAddr)>> {
+    pub fn poll_accept(&self, cx: &mut Context<'_>) -> Poll<Result<(VsockStream, VsockAddr)>> {
         let (inner, addr) = ready!(self.poll_accept_std(cx))?;
         let inner = VsockStream::new(inner)?;
 
@@ -93,7 +93,7 @@ impl VsockListener {
     /// Attempt to accept a connection and create a new connected socket if
     /// successful.
     pub fn poll_accept_std(
-        &mut self,
+        &self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(vsock::VsockStream, VsockAddr)>> {
         loop {
@@ -162,7 +162,7 @@ impl Incoming {
 impl Stream for Incoming {
     type Item = Result<VsockStream>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let (socket, _) = ready!(self.inner.poll_accept(cx))?;
         Poll::Ready(Some(Ok(socket)))
     }

--- a/tests/vsock.rs
+++ b/tests/vsock.rs
@@ -98,7 +98,7 @@ async fn split_vsock() {
     const PORT: u32 = 8002;
 
     let addr = VsockAddr::new(tokio_vsock::VMADDR_CID_LOCAL, PORT);
-    let mut listener = VsockListener::bind(addr).expect("connection failed");
+    let listener = VsockListener::bind(addr).expect("connection failed");
 
     let handle = tokio::task::spawn(async move {
         let (mut stream, _) = listener
@@ -148,7 +148,7 @@ async fn into_split_vsock() {
     const PORT: u32 = 8001;
 
     let addr = VsockAddr::new(tokio_vsock::VMADDR_CID_LOCAL, PORT);
-    let mut listener = VsockListener::bind(addr).expect("connection failed");
+    let listener = VsockListener::bind(addr).expect("connection failed");
 
     let handle = tokio::task::spawn(async move {
         let (mut stream, _) = listener


### PR DESCRIPTION
I encountered trouble when implementing the [`Listener`](https://github.com/rwf2/Rocket/blob/master/core/lib/src/listener/listener.rs#L14) from rocket for `VsockListener`, because it uses `&self`.

```rust
impl rocket::listener::Listener for VsockListener {
    type Accept = (vsock::VsockStream, vsock::VsockAddr);

    type Connection = VsockConnection;

    async fn accept(&self) -> io::Result<Self::Accept> {
        let (stream, addr) = self.listener.accept().await?;
        Ok((stream, addr))
    }
...
}
```
The [TcpListener](https://docs.rs/tokio/latest/src/tokio/net/tcp/listener.rs.html#160-169) from tokio is also using `&self`.

So, I think it should also use `&self` here.