### PR TITLE
feat: add nightly minimum dependencies test

### DIFF
--- a/.github/workflows/bvt.yaml
+++ b/.github/workflows/bvt.yaml
@@ -2,7 +2,7 @@ name: BVT
 on: [pull_request]
 jobs:
   bvt:
-    name: BVT
+    name: BVT (stable)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -16,5 +16,32 @@ jobs:
       run: make clippy
     - name: Build
       run: make tokio_vsock
+    - name: Build all features
+      run: make tokio_vsock_all_features
     - name: Build test_server
       run: make test_server
+  bvt-nightly:
+    name: BVT (nightly)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: install dependencies
+      run: |
+        rustup default nightly
+        rustup target add x86_64-unknown-linux-musl
+        rustup component add rustfmt clippy
+    - name: Format Check
+      run: make fmt
+    - name: Clippy Check
+      run: make clippy
+    - name: Build
+      run: make tokio_vsock
+    - name: Build all features
+      run: make tokio_vsock_all_features
+    - name: Build test_server
+      run: make test_server
+    - name: Build (min-deps)
+      run: |
+        # we need to select the minimum dependencies so remove previously selected versions
+        rm Cargo.lock
+        make tokio_vsock_min_deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ exclude = ["test_fixture"]
 [dependencies]
 bytes = "1.3.0"
 futures = "0.3"
-libc = "0.2.138"
+libc = "0.2.158"
 vsock = "0.5.1"
-tokio = { version = "1", features = ["net", "sync"] }
+# Keep version in sync with [dev-dependencies]
+tokio = { version = "1.34", features = ["net", "sync"] }
 tonic05 = { package = "tonic", version = "0.5", optional = true }
 tonic06 = { package = "tonic", version = "0.6", optional = true }
 tonic07 = { package = "tonic", version = "0.7", optional = true }
@@ -28,7 +29,7 @@ tonic012 = { package = "tonic", version = "0.12", optional = true }
 [dev-dependencies]
 sha2 = "0.10.6"
 rand = "0.8.5"
-tokio = { version = "1", features = ["macros", "rt", "io-util"] }
+tokio = { version = "1.34", features = ["macros", "rt", "io-util"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,12 @@ clean:
 tokio_vsock: $(SRCS)
 	cargo build --lib
 
+tokio_vsock_all_features: $(SRCS)
+	cargo build --lib --all-features
+
+tokio_vsock_min_deps: $(SRCS)
+	cargo build --lib --all-features -Z direct-minimal-versions
+
 test_server: tokio_vsock test_server/src/main.rs
 	cargo build --manifest-path=test_server/Cargo.toml
 


### PR DESCRIPTION
Add a nightly toolchain to test builds using the `-Z direct-minimum-dependencies` flag. This ensures our minimum version requirements are compatible with our source code.

This required bumping some versions:

- libc: `0.2.138` -> `0.2.158` as `vsock-rs` depends on `0.2.158`.
- tokio: `1` -> ~~`1.27` as we depend on methods/trait impls which are only available starting that version.~~ `1.34` as tonic 0.12 requires tokio 1.34

This ensures our minimum `tonic` requirement still compiles.

This should be released as `0.6.1` as requested by @cryo28 on #53 