### PR TITLE
release: v0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-vsock"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["fsyncd", "rust-vsock"]
 description = "Asynchronous Virtio socket support for Rust"
 repository = "https://github.com/rust-vsock/tokio-vsock"


### PR DESCRIPTION
Bump the major version for #54 which changed API and #56 which removed features.

Also this release includes #53 and #55.