### PR TITLE
gh: Increase the maximum word limit for commit message body

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -48,6 +48,6 @@ jobs:
       uses: tim-actions/commit-message-checker-with-regex@v0.3.2
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-        pattern: '^.+(\n.{0,72})*$|^.+\n\s*[^a-zA-Z\s\n]|^.+\n\S+$|\nSigned-off-by: dependabot\[bot\]'
-        error: 'Body line too long (max 72)'
+        pattern: '^.+(\n.{0,150})*$|^.+\n\s*[^a-zA-Z\s\n]|^.+\n\S+$|\nSigned-off-by: dependabot\[bot\]'
+        error: 'Body line too long (max 150)'
         post_error: ${{ env.error_msg }}


### PR DESCRIPTION
The original limit 72 was too strict to follow.